### PR TITLE
Fixing minor issues with qcow image validation

### DIFF
--- a/iso-analysis.py
+++ b/iso-analysis.py
@@ -69,12 +69,12 @@ class MountedIso(RpmPackage):
             run('mount -o ro,loop,offset=%d %s %s' % (start_at * 512, iso_uri, self.temp_dir,))
             self.type = 'image'
         elif '.qcow2' == iso_uri[-6:]:
-            mount_point = run("guestmount -a %s -m /dev/sdx1 %s 2>&1 | grep -e ext4 -e xfs | awk '{ print $2 }'" % (iso_uri, self.temp_dir))
+            mount_point = run("guestmount -a %s -m /dev/sdx1 --ro %s 2>&1 | grep -e ext4 -e xfs | awk '{ print $2 }'" % (iso_uri, self.temp_dir))
             if not mount_point:
-                output = run("guestmount -a %s -m /dev/sdx1 %s" % (iso_uri, self.temp_dir))
+                output = run("guestmount -a %s -m --ro /dev/sdx1 %s" % (iso_uri, self.temp_dir))
                 print output
                 sys.exit(1)
-            run("guestmount -a %s -m %s %s 2>&1 | grep -e ext4 -e xfs | awk '{ print $2 }'" % (iso_uri, mount_point.strip(), self.temp_dir))
+            run("guestmount -a %s -m %s %s --ro 2>&1 | grep -e ext4 -e xfs | awk '{ print $2 }'" % (iso_uri, mount_point.strip(), self.temp_dir))
             self.type = 'image'
         else:
             sys.exit(1)

--- a/iso-analysis.py
+++ b/iso-analysis.py
@@ -84,7 +84,10 @@ class MountedIso(RpmPackage):
         self.package_dict = self.__get_packages__()
 
     def __del__(self):
-        run('umount -l %s' % self.temp_dir)
+        if self.type == 'image':
+            run('guestunmount %s' % self.temp_dir)
+        else:
+            run('umount -l %s' % self.temp_dir)
 
     def __get_files__(self):
         def add_file(file_type):


### PR DESCRIPTION
I'm proposing 2 small fixes of the qcow image validation code:
1. When I run the validation, the qcow image file was changed because guestmount creates a writeable mount point by default. Since we don't need this for the analysis, we could just use read-only mode so that the qcow file would remain the same. This way, one can check checksum of the image and make sure that analysis has been done on the correct version of the qcow image.
2. It's not possible to run the qcow validation under non root user. To fix that, I just used documented way to umount such mount point.
